### PR TITLE
Disable a PM feature that is causing core hangs

### DIFF
--- a/witherspoon.xml
+++ b/witherspoon.xml
@@ -17265,7 +17265,7 @@
 	</attribute>
 	<attribute>
 		<id>SYSTEM_CORE_PERIODIC_QUIESCE_DISABLE</id>
-		<default>0x00</default>
+		<default>0x1</default>
 	</attribute>
 	<attribute>
 		<id>SYSTEM_FAMILY</id>


### PR DESCRIPTION
 -P9 has a live lock condition that CME attempted to "bust"
 -However that buster is resulting in worse problems
 -This change turns off the buster, live lock condition will
  be handled with new inits