### PR TITLE
Update Disable TPM Sensor Value

### DIFF
--- a/witherspoon.xml
+++ b/witherspoon.xml
@@ -15765,7 +15765,7 @@
         <id>/sys-0/disable_tpm_sensor</id>
         <property>
         <id>IPMI_SENSOR_ID</id>
-        <value>0xDD</value>
+        <value>0xE9</value>
         </property>
 </globalSetting>
 <globalSetting>


### PR DESCRIPTION
This small commit just updates the Disable TPM sensor value to 0xE9.